### PR TITLE
Export raw Authy data to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Output:
 
 - Generates TOTP QR codes
 - Generates a aegis_plain JSON file called `exported.json`
+- Generates a XML file called `exported_authy.xml` with the raw Authy database
+
+**NOTE**: To ensure the safety of your TOTP tokens, make sure to delete these exports after use!
 
 
 ## Demo

--- a/authy-offline.py
+++ b/authy-offline.py
@@ -54,10 +54,8 @@ def onMessage(message, data):
         # print(u"[*] {0}".format(message['payload']))
         print("[+] Extracting Authy TOTP Tokens... ")
         # Do some magic
-        dataFile = message['payload'].replace('&quot;','"')
+        dataFile = message['payload'].replace('&quot;', '"')
         parseXML(dataFile)
-        print("-----------------------------------------------------")
-        print(u"{0}".format(dataFile))
     else:
         print(message)
 
@@ -65,6 +63,10 @@ def exportJSON(data):
     # Create a aegis_plain export file
     with open('exported.json', 'w') as f:
         json.dump(data, f)
+
+def exportXML(dataFile: str) -> None:
+    with open('exported_authy.xml', 'a') as f:
+        f.write(dataFile)
 
 def parseXML(dataFile):
     root = ET.fromstring(dataFile) 
@@ -150,6 +152,8 @@ def parseXML(dataFile):
     
     # write JSON to file
     exportJSON(aegis_plain)
+    exportXML(dataFile)
+    print("Press any key to exit")
     
 # Show what Frida script we are running
 #print(jsCode)


### PR DESCRIPTION
For improved debugging, this exports the raw Authy data to a file,
rather than just printing it to console.

Here we also print a message prompting the user to exit once the message
parsing has finished! (I was initially confused by the script seeming to "hang" here)